### PR TITLE
Added Debug trait to error::Error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 use serde_derive::Deserialize;
 use std::fmt;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(untagged)]
 pub enum Error {
     #[serde(skip_deserializing)]


### PR DESCRIPTION
Hey @kayleg,

This pull request that adds the `Debug` trait to `cloud_pub::error::Error` and consequently, the `unwrap` method to any`Result` instances containing this error type.

More info [here](https://stackoverflow.com/questions/30994176/result-has-no-method-called-unwrap).

