### PR TITLE
Add trivial implementation of std::error::Error for Error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -39,6 +39,8 @@ impl fmt::Display for Error {
     }
 }
 
+impl std::error::Error for Error {}
+
 impl From<goauth::error::GOErr> for Error {
     fn from(err: goauth::error::GOErr) -> Error {
         Error::PubSubAuth(err)


### PR DESCRIPTION
This adds the trivial error implementation required by issue #3 

Closes #3 

Signed-off-by: Bruce Guenter <bruce@untroubled.org>