### PR TITLE
Add possibility to use google pubsub emulator (given PUBSUB_EMULATOR_HOST env)

### DIFF
--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -3,7 +3,15 @@ use crate::error;
 use crate::message::{FromPubSubMessage, Message};
 use bytes::buf::BufExt as _;
 use hyper::{Method, StatusCode};
+use lazy_static::lazy_static;
 use serde_derive::{Deserialize, Serialize};
+use std::env;
+
+lazy_static! {
+    static ref PUBSUB_HOST: String = env::var("PUBSUB_EMULATOR_HOST")
+        .map(|host| format!("http://{}", host))
+        .unwrap_or_else(|_| String::from("https://pubsub.googleapis.com"));
+}
 
 #[derive(Deserialize)]
 struct Response {
@@ -35,7 +43,7 @@ impl Subscription {
             .as_ref()
             .expect("Subscription was not created using a client");
 
-        let uri: hyper::Uri = format!("https://pubsub.googleapis.com/v1/{}:acknowledge", self.name)
+        let uri: hyper::Uri = format!("{}/v1/{}:acknowledge", *PUBSUB_HOST, self.name)
             .parse()
             .unwrap();
 
@@ -57,7 +65,7 @@ impl Subscription {
             .as_ref()
             .expect("Subscription was not created using a client");
 
-        let uri: hyper::Uri = format!("https://pubsub.googleapis.com/v1/{}:pull", self.name)
+        let uri: hyper::Uri = format!("{}/v1/{}:pull", *PUBSUB_HOST, self.name)
             .parse()
             .unwrap();
 
@@ -104,7 +112,7 @@ impl Subscription {
             .client
             .expect("Subscription was not created using a client");
 
-        let uri: hyper::Uri = format!("https://pubsub.googleapis.com/v1/{}", self.name)
+        let uri: hyper::Uri = format!("{}/v1/{}", *PUBSUB_HOST, self.name)
             .parse()
             .unwrap();
 

--- a/src/topic.rs
+++ b/src/topic.rs
@@ -4,10 +4,18 @@ use crate::subscription::*;
 use crate::EncodedMessage;
 use bytes::buf::BufExt as _;
 use hyper::{Method, StatusCode};
+use lazy_static::lazy_static;
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 use serde::de::DeserializeOwned;
 use serde_derive::{Deserialize, Serialize};
+use std::env;
+
+lazy_static! {
+    static ref PUBSUB_HOST: String = env::var("PUBSUB_EMULATOR_HOST")
+        .map(|host| format!("http://{}", host))
+        .unwrap_or_else(|_| String::from("https://pubsub.googleapis.com"));
+}
 
 #[derive(Deserialize, Serialize)]
 pub struct Topic {
@@ -38,7 +46,7 @@ impl Topic {
             client: None,
         };
 
-        let uri: hyper::Uri = format!("https://pubsub.googleapis.com/v1/{}", new_subscription.name)
+        let uri: hyper::Uri = format!("{}/v1/{}", *PUBSUB_HOST, new_subscription.name)
             .parse()
             .unwrap();
 
@@ -54,7 +62,7 @@ impl Topic {
         &self,
         data: T,
     ) -> Result<PublishMessageResponse, error::Error> {
-        let uri: hyper::Uri = format!("https://pubsub.googleapis.com/v1/{}:publish", self.name)
+        let uri: hyper::Uri = format!("{}/v1/{}:publish", *PUBSUB_HOST, self.name)
             .parse()
             .unwrap();
 


### PR DESCRIPTION
Wanted to use google beta pubsub emulator and was thinking it could be useful to others.

### Guide
https://cloud.google.com/sdk/gcloud/reference/beta/emulators/pubsub

### Gotcha
Make sure to create a topic locally before sending a subscription, it won't sync with the topics you have created on gcloud