### PR TITLE
First tick will return right away so we should call tick prior to doing anything else

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -102,11 +102,11 @@ impl Client {
             let mut int = time::interval(interval);
             loop {
                 if c.is_running() {
+                    int.tick().await;
                     println!("Renewing pubsub token");
                     if let Err(e) = client.refresh_token() {
                         eprintln!("Failed to update token: {}", e);
                     }
-                    int.tick().await;
                 }
             }
         };


### PR DESCRIPTION
If not we would end up with 2 calls to client.refresh_token

```
     Running `target/debug/meet-api`
[2020-06-03T05:48:42Z INFO  meet_api] Got fresh token
Renewing pubsub token
[2020-06-03T05:48:42Z INFO  meet_backend_shared::xirsys] Making get ice servers call
Renewing pubsub token
```

