### PR TITLE
Proposal for fix for loss of relation between message and ack_id.

### DIFF
--- a/examples/long_lived.rs
+++ b/examples/long_lived.rs
@@ -27,11 +27,12 @@ fn schedule_pubsub_pull(subscription: Arc<Subscription>) {
     task::spawn(async move {
         while subscription.client().is_running() {
             match subscription.get_messages::<UpdatePacket>().await {
-                Ok((packets, acks)) => {
-                    for packet in packets {
+                Ok(packets) => {
+                    for packet in &packets {
                         println!("Received: {:?}", packet);
                     }
 
+                    let acks: Vec<String> = packets.into_iter().map(|packet| packet.0).collect();
                     if !acks.is_empty() {
                         let s = Arc::clone(&subscription);
                         task::spawn(async move {

--- a/examples/serde.rs
+++ b/examples/serde.rs
@@ -41,11 +41,12 @@ async fn main() {
 
     let order_sub = Arc::new(pubsub.subscribe(config.pubsub_subscription));
     match order_sub.clone().get_messages::<UpdatePacket>().await {
-        Ok((packets, acks)) => {
-            for packet in packets {
+        Ok(packets) => {
+            for packet in &packets {
                 println!("Received: {:?}", packet);
             }
 
+            let acks: Vec<String> = packets.into_iter().map(|packet| packet.0).collect();
             if !acks.is_empty() {
                 task::spawn(async move { order_sub.acknowledge_messages(acks).await })
                     .await // This will block until acknowledgement is complete

--- a/examples/singleshot.rs
+++ b/examples/singleshot.rs
@@ -38,11 +38,12 @@ async fn main() {
 
     let order_sub = Arc::new(pubsub.subscribe(config.pubsub_subscription));
     match order_sub.clone().get_messages::<UpdatePacket>().await {
-        Ok((packets, acks)) => {
-            for packet in packets {
+        Ok(packets) => {
+            for packet in &packets {
                 println!("Received: {:?}", packet);
             }
 
+            let acks: Vec<String> = packets.into_iter().map(|packet| packet.0).collect();
             if !acks.is_empty() {
                 task::spawn(async move { order_sub.acknowledge_messages(acks).await })
                     .await // This will block until acknowledgement is complete

--- a/examples/subscribe_to_topic.rs
+++ b/examples/subscribe_to_topic.rs
@@ -33,17 +33,18 @@ async fn main() {
     let sub = topic.subscribe().await.expect("Failed to subscribe");
 
     println!("Subscribed to topic with: {}", sub.name);
-    let (packets, acks) = sub
+    let packets = sub
         .clone()
         .get_messages::<UpdatePacket>()
         .await
         .expect("Error Checking PubSub");
 
-    for packet in packets {
+    for packet in &packets {
         println!("Received: {:?}", packet);
     }
 
-    if !acks.is_empty() {
+    if !packets.is_empty() {
+        let acks = packets.into_iter().map(|packet| packet.0).collect();
         sub.acknowledge_messages(acks).await;
     } else {
         println!("Cleaning up");


### PR DESCRIPTION
This PR attempts a fix for #14 

This changes the returned values from `get_messages` from a tuple of vectors with `ack_ids` and message to a `HashMap` where `ack_id` is the key of a `Result` that contains either the successfully deserialized message or the error that occurred.

