### PR TITLE
Add attributes accessor to EncodedMessage

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -22,6 +22,10 @@ impl EncodedMessage {
         base64::decode(&self.data)
     }
 
+    pub fn attributes(&self) -> &Option<HashMap<String, String>> {
+        &self.attributes
+    }
+
     pub fn new<T: serde::Serialize>(data: &T, attributes: Option<HashMap<String, String>>) -> Self {
         let json = serde_json::to_string(data).unwrap();
         let data = base64::encode(&json);

--- a/src/message.rs
+++ b/src/message.rs
@@ -22,8 +22,8 @@ impl EncodedMessage {
         base64::decode(&self.data)
     }
 
-    pub fn attributes(&self) -> &Option<HashMap<String, String>> {
-        &self.attributes
+    pub fn attributes(&self) -> Option<&HashMap<String, String>> {
+        self.attributes.as_ref()
     }
 
     pub fn new<T: serde::Serialize>(data: &T, attributes: Option<HashMap<String, String>>) -> Self {


### PR DESCRIPTION
In our processing we rely on attributes to dispatch messages.