### PR TITLE
Opening up public access to the EncodedMessage struct for binary data.

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -5,9 +5,9 @@ use std::collections::HashMap;
 
 #[derive(Deserialize, Clone, Serialize)]
 pub struct EncodedMessage {
-    data: String,
+    pub data: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    attributes: Option<HashMap<String, String>>,
+    pub attributes: Option<HashMap<String, String>>,
 }
 
 pub trait FromPubSubMessage


### PR DESCRIPTION
Hello,

I ran into an issue where we are sending protobuf on pubsub.  Pulling from a subscription with a protobuf isn't an issue.  When I went to publish back to the topic, the data was being serialized and was erroring on the consumer.   This is a quick fix to address the issue.  As the maintainer of the lib, I am hoping you have some guidance on how you would like to deal with this type of data going forward.  To address the issue, I simply made my own EncodedMessage and base64 encoded my  payload.  I am happy to make changes based on your recommendations.

Thank you for the crate wonderful package.